### PR TITLE
Markdownの導入

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,32 +3,18 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby '2.7.2'
 
-# Bundle edge Rails instead: gem 'rails', github: 'rails/rails', branch: 'main'
 gem 'rails', '~> 6.1.3', '>= 6.1.3.1'
-# Use postgresql as the database for Active Record
 gem 'pg', '~> 1.1'
-# Use Puma as the app server
 gem 'puma', '~> 5.0'
-# Use SCSS for stylesheets
 gem 'sass-rails', '>= 6'
-# Transpile app-like JavaScript. Read more: https://github.com/rails/webpacker
 gem 'webpacker', '~> 5.0'
-# Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks
 gem 'turbolinks', '~> 5'
-# Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
-# Use Redis adapter to run Action Cable in production
-# gem 'redis', '~> 4.0'
-# Use Active Model has_secure_password
-# gem 'bcrypt', '~> 3.1.7'
 
-# Use Active Storage variant
-# gem 'image_processing', '~> 1.2'
 
-# Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.4', require: false
-
+# マークダウン記法の文字列をHTMLに変換
+gem 'redcarpet'
 group :development, :test do
-  # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,8 @@ gem 'turbolinks', '~> 5'
 gem 'bootsnap', '>= 1.4.4', require: false
 # マークダウン記法の文字列をHTMLに変換
 gem 'redcarpet'
+# シンタックスハイライト
+gem 'coderay'
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,8 +73,6 @@ GEM
       activesupport (>= 4.2.0)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
-    jbuilder (2.11.2)
-      activesupport (>= 5.0.0)
     listen (3.5.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -134,6 +132,7 @@ GEM
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    redcarpet (3.5.1)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
     sassc (2.4.0)
@@ -181,12 +180,12 @@ PLATFORMS
 DEPENDENCIES
   bootsnap (>= 1.4.4)
   byebug
-  jbuilder (~> 2.7)
   listen (~> 3.3)
   pg (~> 1.1)
   puma (~> 5.0)
   rack-mini-profiler (~> 2.0)
   rails (~> 6.1.3, >= 6.1.3.1)
+  redcarpet
   sass-rails (>= 6)
   spring
   turbolinks (~> 5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,6 +65,7 @@ GEM
       msgpack (~> 1.0)
     builder (3.2.4)
     byebug (11.1.3)
+    coderay (1.1.3)
     concurrent-ruby (1.1.8)
     crass (1.0.6)
     erubi (1.10.0)
@@ -180,6 +181,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap (>= 1.4.4)
   byebug
+  coderay
   listen (~> 3.3)
   pg (~> 1.1)
   puma (~> 5.0)

--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -1,0 +1,26 @@
+module MarkdownHelper
+  def markdown(text)
+    markdown = Redcarpet::Markdown.new(html_renderer, markdown_extensions)
+    markdown.render(text).html_safe
+  end
+
+  private
+
+  def html_renderer
+    Redcarpet::Render::HTML
+  end
+
+  def markdown_extensions
+    {
+      autolink: true,
+      space_after_headers: true,
+      no_intra_emphasis: true,
+      fenced_code_blocks: true,
+      tables: true,
+      hard_wrap: true,
+      xhtml: true,
+      lax_html_blocks: true,
+      strikethrough: true
+    }
+  end
+end

--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -7,7 +7,11 @@ module MarkdownHelper
   private
 
   def html_renderer
-    Redcarpet::Render::HTML
+    ::Coderayify.new(
+      filter_html: true,
+      hard_wrap: true,
+      link_attributes: {rel: 'nofollow', target: "_blank" }
+    )
   end
 
   def markdown_extensions

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -6,7 +6,6 @@
   <thead>
     <tr>
       <th>Title</th>
-      <th>Content</th>
       <th colspan="3"></th>
     </tr>
   </thead>
@@ -15,7 +14,6 @@
     <% @posts.each do |post| %>
       <tr>
         <td><%= post.title %></td>
-        <td><%= post.content %></td>
         <td><%= link_to 'Show', post %></td>
         <td><%= link_to 'Edit', edit_post_path(post) %></td>
         <td><%= link_to 'Destroy', post, method: :delete, data: { confirm: 'Are you sure?' } %></td>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -7,7 +7,10 @@
 
 <p>
   <strong>Content:</strong>
-  <%= @post.content %>
+  <%= renderer = Redcarpet::Render::HTML %>
+  <% extensions = { tables: true }%>
+  <% markdown = Redcarpet::Markdown.new(renderer, extensions) %>
+  <%= markdown.render(@post.content).html_safe %>
 </p>
 
 <%= link_to 'Edit', edit_post_path(@post) %> |

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -7,10 +7,7 @@
 
 <p>
   <strong>Content:</strong>
-  <%= renderer = Redcarpet::Render::HTML %>
-  <% extensions = { tables: true }%>
-  <% markdown = Redcarpet::Markdown.new(renderer, extensions) %>
-  <%= markdown.render(@post.content).html_safe %>
+  <%= markdown(@post.content) %>
 </p>
 
 <%= link_to 'Edit', edit_post_path(@post) %> |

--- a/config/application.rb
+++ b/config/application.rb
@@ -24,15 +24,8 @@ module MarkdownSample
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.1
 
-    # Configuration for the application, engines, and railties goes here.
-    #
-    # These settings can be overridden in specific environments using the files
-    # in config/environments, which are processed later.
-    #
-    # config.time_zone = "Central Time (US & Canada)"
-    # config.eager_load_paths << Rails.root.join("extras")
-
-    # Don't generate system test files.
+    # lib/autoloads ディレクトリ配下のファイルを読み込む
+    config.autoload_paths << Rails.root.join("lib/autoloads")
     config.generators.system_tests = nil
   end
 end

--- a/lib/autoloads/coderayify.rb
+++ b/lib/autoloads/coderayify.rb
@@ -1,0 +1,34 @@
+class Coderayify < Redcarpet::Render::HTML
+  def block_code(code, language)
+    # コードブロックの拡張子を取得
+    ext = retrieve_extension(language)
+    # 適用するシンタックスハイライトの言語を決める
+    lang = case ext
+           when "rb"
+             :ruby
+           when "yml"
+             :yaml
+           else
+             ext.to_sym
+           end
+    CodeRay.scan(code, lang).div
+  end
+
+  private
+
+  # 拡張子を取得するメソッド
+  def retrieve_extension(language)
+    if language.blank?
+      # コードブロックの開始宣言で「```」の後に拡張子が与えられていない場合は md 形式とみなす
+      "md"
+    elsif language.include?(":")
+      # コードブロックの開始宣言が「```rb:sample.rb」の場合は rb 形式とみなす
+      language.split(':')[0]
+    elsif language.include?(".")
+      # コードブロックの開始宣言が「```sample.rb」の場合は rb 形式とみなす
+      language.split('.')[-1]
+    else
+      language
+    end
+  end
+end


### PR DESCRIPTION
## 実装内容

- Markdownの導入
  - Node.jsのインストールと新規投稿のテストを確認
  - Redcarpetの導入
  - ヘルパーメソッドの作成
  -  CodeRayの導入

## 参考
[Markdownの導入](https://www.yanbaru-code.com/texts/224)